### PR TITLE
fix(config): fix plugin file path generation and parsing bugs

### DIFF
--- a/.github/workflows/admin-server-cicd.yml
+++ b/.github/workflows/admin-server-cicd.yml
@@ -8,6 +8,7 @@ on:
       - 'crates/plugin/**'
       - 'Cargo.toml'
       - '.github/workflows/admin-server-cicd.yml'
+  workflow_dispatch:
 
 env:
   ARTIFACT_DIR: release-artifacts

--- a/crates/config/src/service/fs/mod.rs
+++ b/crates/config/src/service/fs/mod.rs
@@ -61,11 +61,12 @@ where
         // collect plugin
         if let Ok(mut plugin_dir) = tokio::fs::read_dir(self.plugin_dir()).await.inspect_err(|e| tracing::debug!("fail to read plugin dir {e}")) {
             while let Some(entry) = plugin_dir.next_entry().await? {
-                let Ok(file_name) = entry.file_name().into_string() else {
+                let path = entry.path();
+                let Some(file_stem) = path.file_stem().and_then(OsStr::to_str) else {
                     continue;
                 };
-                let plugin_id = PluginInstanceId::from_file_stem(&file_name);
-                let spec: serde_json::Value = self.format.de(&tokio::fs::read(entry.path()).await?)?;
+                let plugin_id = PluginInstanceId::from_file_stem(file_stem);
+                let spec: serde_json::Value = self.format.de(&tokio::fs::read(&path).await?)?;
                 config.plugins.insert(plugin_id, spec);
             }
         };
@@ -224,7 +225,8 @@ where
 
     pub fn plugin_path(&self, id: &PluginInstanceId) -> PathBuf {
         let file_stem = id.as_file_stem();
-        self.plugin_dir().join(file_stem).with_extension(self.format.extension())
+        let ext = self.format.extension().to_str().unwrap_or("json");
+        self.plugin_dir().join(format!("{}.{}", file_stem, ext))
     }
     pub fn extract_gateway_name_from_route_dir(&self, path: &Path) -> Option<String> {
         if path.extension()? == OsStr::from_bytes(ROUTE_DIR.as_bytes()) {


### PR DESCRIPTION
Two critical bugs in plugin file handling:

1. **Write Bug (plugin_path)**: PathBuf::with_extension() replaces the last extension instead of appending. For Named plugins with file_stem='auth.auth', calling with_extension('json') produces 'auth.json' instead of 'auth.auth.json'.

   Fix: Manually format the filename instead of using with_extension().

2. **Read Bug (collect_config)**: Used entry.file_name() which includes the extension, but from_file_stem() expects stem only. This caused 'auth.json' to be parsed as Named{name:'json'} instead of Mono.

   Fix: Use path.file_stem() to extract stem without extension.

Impact:
- Named plugins were saved with wrong filenames
- Mono/Anon plugins were misidentified as Named on reload
- Routes failed to mount plugins due to ID mismatch